### PR TITLE
feat: Allow exact matching for document fields.

### DIFF
--- a/packages/indyscan-storage/src/es/es-query-builder.js
+++ b/packages/indyscan-storage/src/es/es-query-builder.js
@@ -28,11 +28,7 @@ function esFilterByNYM (nym) {
 function esFilterByAttribName (name) {
   return {
     match: {
-      'idata.expansion.idata.txn.data.raw': {
-        'query': name,
-        'analyzer': 'standard'
-      }
-
+      'idata.expansion.idata.txn.data.raw': name
     }
   }
 }
@@ -48,10 +44,7 @@ function esMatchFromDID(dest) {
 function esMatchSchemaName(name) {
   return {
     match: {
-      "idata.expansion.idata.txn.data.data.name": {
-        "query": name,
-        "analyzer": "standard"
-      }
+      "idata.expansion.idata.txn.data.data.name": name
     }
   }
 }
@@ -59,10 +52,7 @@ function esMatchSchemaName(name) {
 function esMatchSchemaVersion(version) {
   return {
     match: {
-      "idata.expansion.idata.txn.data.data.version": {
-        "query": version,
-        "analyzer": "standard"
-      }
+      "idata.expansion.idata.txn.data.data.version": version
     }
   }
 }
@@ -80,10 +70,7 @@ function esMatchSchemaRef(ref) {
 function esMatchTxnId(id) {
   return {
     match: {
-      "idata.expansion.idata.txnMetadata.txnId": {
-        "query": id,
-        "analyzer": "keyword"
-      }
+      "idata.expansion.idata.txnMetadata.txnId": id
     }
   }
 }

--- a/packages/indyscan-storage/src/es/storage-write-es.js
+++ b/packages/indyscan-storage/src/es/storage-write-es.js
@@ -43,6 +43,14 @@ async function createStorageWriteEs (esClient, esIndex, esReplicaCount, logger =
     for (const [field, fieldMapping] of Object.entries(fieldMappings)) {
       esMappingDefinition.properties[`idata.${formatName}.idata.${field}`] = fieldMapping
     }
+
+    // Allow exact matching for these fields. 
+    esMappingDefinition.properties['idata.expansion.idata.txn.data.dest'] = { type: 'keyword' }
+    esMappingDefinition.properties['idata.expansion.idata.txn.data.raw'] = { type: 'keyword' }
+    esMappingDefinition.properties['idata.expansion.idata.txn.metadata.from'] = { type: 'keyword' }
+    esMappingDefinition.properties['idata.expansion.idata.txn.data.data.name'] = { type: 'keyword' }
+    esMappingDefinition.properties['idata.expansion.idata.txn.data.data.version'] = { type: 'keyword' }
+    esMappingDefinition.properties['idata.expansion.idata.txnMetadata.txnId'] = { type: 'keyword' }
     esMappingDefinition.properties[`idata.${formatName}.imeta.subledger`] = { type: 'keyword' }
     esMappingDefinition.properties[`idata.${formatName}.imeta.seqNo`] = { type: 'integer' }
     try {


### PR DESCRIPTION
Set property type for the following fields to `keyword`

`idata.expansion.idata.txn.data.dest`
`idata.expansion.idata.txn.data.raw`
`idata.expansion.idata.txn.metadata.from`
`idata.expansion.idata.txn.data.data.name`
`idata.expansion.idata.txn.data.data.version`
`idata.expansion.idata.txnMetadata.txnId`
